### PR TITLE
ENH: add conda environment using cn mirrors

### DIFF
--- a/environment-cn.yml
+++ b/environment-cn.yml
@@ -1,0 +1,21 @@
+name: quantecon
+channels:
+  - default
+  - conda-forge
+dependencies:
+  - python=3.11
+  - anaconda=2024.06
+  - pip
+  - pip:
+    - jupyter-book==0.15.1
+    - docutils==0.17.1
+    - quantecon-book-theme==0.7.2
+    - sphinx-tojupyter==0.3.0
+    - sphinxext-rediraffe==0.2.7
+    - sphinx-exercise==0.4.1
+    - sphinx-proof==0.2.0
+    - ghp-import==1.1.0
+    - sphinxcontrib-youtube==1.1.0
+    - sphinx-togglebutton==0.3.1
+    - sphinx_reredirects==0.1.3
+    - --index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple


### PR DESCRIPTION
This PR adds `environment-cn.yml` which aids in setting up the `quantecon` software environment when in China using mirror for PyPI packages.

This environment should only be used within China. 

Fixes #108 