### PR TITLE
MAINT: switch runner name for quantecon-large

### DIFF
--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest-m
+    runs-on: quantecon-large
     container:
       image: us-docker.pkg.dev/colab-images/public/runtime:latest
     steps:


### PR DESCRIPTION
This PR switches the runner name for QuantEcon large instances. 