### PR TITLE
MAINT: update quantecon software environment

### DIFF
--- a/environment-cn.yml
+++ b/environment-cn.yml
@@ -7,15 +7,14 @@ dependencies:
   - anaconda=2024.10
   - pip
   - pip:
-    - jupyter-book==0.15.1
-    - docutils==0.17.1
-    - quantecon-book-theme==0.7.2
+    - jupyter-book==1.0.3
+    - quantecon-book-theme==0.7.6
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
-    - sphinx-exercise==0.4.1
+    - sphinx_reredirects==0.1.4
+    - sphinx-exercise==1.0.1
     - sphinx-proof==0.2.0
     - ghp-import==1.1.0
-    - sphinxcontrib-youtube==1.1.0
-    - sphinx-togglebutton==0.3.1
-    - sphinx_reredirects==0.1.3
+    - sphinxcontrib-youtube==1.3.0 #Version 1.3.0 is required as quantecon-book-theme is only compatible with sphinx<=5
+    - sphinx-togglebutton==0.3.2
     - --index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple

--- a/environment.yml
+++ b/environment.yml
@@ -1,21 +1,19 @@
 name: quantecon
 channels:
   - default
-  - conda-forge
 dependencies:
   - python=3.12
   - anaconda=2024.10
   - pip
   - pip:
-    - jupyter-book==0.15.1
-    - docutils==0.17.1
-    - quantecon-book-theme==0.7.2
+    - jupyter-book==1.0.3
+    - quantecon-book-theme==0.7.6
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
-    - sphinx-exercise==0.4.1
+    - sphinx-reredirects==0.1.4
+    - sphinx-exercise==1.0.1
     - sphinx-proof==0.2.0
     - ghp-import==1.1.0
-    - sphinxcontrib-youtube==1.1.0
-    - sphinx-togglebutton==0.3.1
-    - sphinx_reredirects==0.1.3
+    - sphinxcontrib-youtube==1.3.0 #Version 1.3.0 is required as quantecon-book-theme is only compatible with sphinx<=5
+    - sphinx-togglebutton==0.3.2
 


### PR DESCRIPTION
This PR

- [x] upgrades to `jupyter-book==1.0.3` and associate packages
- [ ] runs a full execution check
- [ ] re-enables the build cache
- [ ] enables testing of quantecon environment and lecture build on windows