### PR TITLE
ENH: enable download notebook builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,12 @@ jobs:
       #   with:
       #     name: execution-reports
       #     path: _build/latex/reports
-      # - name: Build Download Notebooks (sphinx-tojupyter)
-      #   shell: bash -l {0}
-      #   run: |
-      #     jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter
-      #     mkdir -p _build/html/_notebooks
-      #     cp -u _build/jupyter/*.ipynb _build/html/_notebooks
+      - name: Build Download Notebooks (sphinx-tojupyter)
+        shell: bash -l {0}
+        run: |
+          jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter
+          mkdir -p _build/html/_notebooks
+          cp -u _build/jupyter/*.ipynb _build/html/_notebooks
       # Build HTML (Website)
       # BUG: rm .doctress to remove `sphinx` rendering issues for ipywidget mimetypes
       # and clear the sphinx cache for building final HTML documents.


### PR DESCRIPTION
This PR enables

- [x] building of download notebooks via `sphinx-tojupyter`