### PR TITLE
MAINT: review config for lecture builds

### DIFF
--- a/environment-cn.yml
+++ b/environment-cn.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.3
-    - quantecon-book-theme==0.7.6
+    - quantecon-book-theme==0.8.2
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx_reredirects==0.1.4

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.3
-    - quantecon-book-theme==0.7.6
+    - quantecon-book-theme==0.8.2
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-reredirects==0.1.4

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -65,7 +65,7 @@ sphinx:
       header_organisation: QuantEcon
       repository_url: https://github.com/QuantEcon/lecture-intro.zh-cn
       nb_repository_url: https://github.com/QuantEcon/lecture-intro.zh-cn.notebooks
-      download_nb_path: https://github.com/QuantEcon/lecture-intro.zh-cn
+      download_nb_path: https://quantecon.github.io/lecture-intro.zh-cn/
       twitter: quantecon
       twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
       og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -25,7 +25,7 @@ execute:
     - '_static/*'
 
 html:
-  baseurl: https://intro-cn.quantecon.org/
+  baseurl: https://quantecon.github.io/lecture-intro.zh-cn
 
 bibtex_bibfiles:
   - _static/quant-econ.bib
@@ -63,15 +63,15 @@ sphinx:
       dark_logo: quantecon-logo-transparent.png
       header_organisation_url: https://quantecon.org
       header_organisation: QuantEcon
-      repository_url: https://github.com/QuantEcon/lecture-python-intro
-      nb_repository_url: https://github.com/QuantEcon/lecture-python-intro.notebooks
+      repository_url: https://github.com/QuantEcon/lecture-intro.zh-cn
+      nb_repository_url: https://github.com/QuantEcon/lecture-intro.zh-cn.notebooks
       twitter: quantecon
       twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
       og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png
       description: 本课程是由托马斯·萨金特（Thomas J. Sargent）和约翰·斯塔胡斯基（John Stachurski）设计和撰写的计算经济学入门讲座。
       keywords: Python, QuantEcon, Quantitative Economics, Economics, Sloan, Alfred P. Sloan Foundation, Tom J. Sargent, John Stachurski
-      analytics:
-        google_analytics_id: G-QDS1YRJNGM
+      # analytics:
+      #   google_analytics_id: G-QDS1YRJNGM
       launch_buttons:
         notebook_interface        : classic  # The interface interactive links will activate ["classic", "jupyterlab"]
         binderhub_url             : https://mybinder.org  # The URL of the BinderHub (e.g., https://mybinder.org)
@@ -118,8 +118,8 @@ sphinx:
       ak2:   https://python.quantecon.org/ak2.html
     tojupyter_static_file_path: ["_static"]
     tojupyter_target_html: true
-    tojupyter_urlpath: "https://intro.quantecon.org/"
-    tojupyter_image_urlpath: "https://intro.quantecon.org/_static/"
+    tojupyter_urlpath: "https://quantecon.github.io/lecture-intro.zh-cn/"
+    tojupyter_image_urlpath: "https://quantecon.github.io/lecture-intro.zh-cn/_static/"
     tojupyter_lang_synonyms: ["ipython", "ipython3", "python"]
     tojupyter_kernels:
       python3:

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -65,6 +65,7 @@ sphinx:
       header_organisation: QuantEcon
       repository_url: https://github.com/QuantEcon/lecture-intro.zh-cn
       nb_repository_url: https://github.com/QuantEcon/lecture-intro.zh-cn.notebooks
+      download_nb_path: https://github.com/QuantEcon/lecture-intro.zh-cn
       twitter: quantecon
       twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
       og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -65,7 +65,7 @@ sphinx:
       header_organisation: QuantEcon
       repository_url: https://github.com/QuantEcon/lecture-intro.zh-cn
       nb_repository_url: https://github.com/QuantEcon/lecture-intro.zh-cn.notebooks
-      download_nb_path: https://quantecon.github.io/lecture-intro.zh-cn/
+      download_nb_path: https://quantecon.github.io/lecture-intro.zh-cn
       twitter: quantecon
       twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
       og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png


### PR DESCRIPTION
This reviews and updates the `_config.yml` file, and fixes the issue effecting download notebooks

- [x] This will require `quantecon-book-theme==0.8.2` before it can be merged