### PR TITLE
FIX: rename conda channel 'default' to 'defaults'

### DIFF
--- a/environment-cn.yml
+++ b/environment-cn.yml
@@ -1,6 +1,6 @@
 name: quantecon
 channels:
-  - default
+  - defaults
   - conda-forge
 dependencies:
   - python=3.13

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: quantecon
 channels:
-  - default
+  - defaults
 dependencies:
   - python=3.13
   - anaconda=2025.12


### PR DESCRIPTION
Fixes the conda channel name from `default` (singular) to `defaults` (plural) in both `environment.yml` and `environment-cn.yml`.

Per the [conda docs](https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html), the correct channel name is `defaults` (plural). Using `default` can be treated as an unknown channel and cause `conda env create` to fail.

Addresses Copilot review feedback from #209.