### PR TITLE
ENH: add review-translations workflow for action-translation

### DIFF
--- a/.github/workflows/review-translations.yml
+++ b/.github/workflows/review-translations.yml
@@ -2,7 +2,15 @@ name: Review Translations
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: review-translations-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   review:

--- a/.github/workflows/review-translations.yml
+++ b/.github/workflows/review-translations.yml
@@ -1,0 +1,25 @@
+name: Review Translations
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  review:
+    if: contains(github.event.pull_request.labels.*.name, 'action-translation')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: QuantEcon/action-translation@v0.14.1
+        with:
+          mode: review
+          source-repo: QuantEcon/lecture-python-intro
+          source-language: en
+          target-language: zh-cn
+          docs-folder: lectures
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds the `review-translations.yml` workflow to enable automatic translation review on PRs created by [`action-translation`](https://github.com/QuantEcon/action-translation).

## How it works

1. The **source repo** (`lecture-python-intro`) runs a `sync-translations-zh-cn.yml` workflow on merged PRs that touch `lectures/**/*.md` or `lectures/_toc.yml`. It translates changed content and opens a PR in this repo with the `action-translation` label.

2. This **reviewer workflow** triggers on PRs labeled `action-translation`, running `QuantEcon/action-translation@v0.14.1` in `review` mode to validate the translation quality.

## Setup based on

- [`lecture-python-programming`](https://github.com/QuantEcon/lecture-python-programming/blob/main/.github/workflows/sync-translations-zh-cn.yml) (source sync workflow)
- [`lecture-python-programming.zh-cn`](https://github.com/QuantEcon/lecture-python-programming.zh-cn/blob/main/.github/workflows/review-translations.yml) (target review workflow)

## Required secrets

- `ANTHROPIC_API_KEY` — for LLM-based translation review
- `GITHUB_TOKEN` — automatically provided

## Related

- Source repo sync workflow: [lecture-python-intro#723](https://github.com/QuantEcon/lecture-python-intro/pull/723)